### PR TITLE
Fix tic tac toe indentation error

### DIFF
--- a/core/main/src/main/java/com/rk/terminal/ui/screens/terminal/AgentOrchestrator.kt
+++ b/core/main/src/main/java/com/rk/terminal/ui/screens/terminal/AgentOrchestrator.kt
@@ -376,6 +376,11 @@ class AgentOrchestrator(
     }
 
     suspend fun generatePlan(userGoal: String): Plan? = withContext(Dispatchers.IO) {
+        // Starting a brand-new plan for this chat session. Clear any prior progress and
+        // ephemeral observations so old task ids (e.g., t1, t2) from previous plans do not
+        // incorrectly mark new plan tasks as done.
+        runCatching { if (progressFile.exists()) progressFile.delete() }
+        observations.clear()
         val wdPath = workingDirProvider()
         val wd = File(wdPath)
         val workspaceInfo = if (wd.exists() && wd.isDirectory) listTopLevel(wd) else JSONObject().put("path", wdPath).put("items", JSONArray()).toString()


### PR DESCRIPTION
Clear stale task progress when generating a new plan.

Previously, old task progress (`progress.json`) from a prior plan in the same chat session would incorrectly mark new plan tasks as done, leading to the 'Proceed' button being disabled. This change ensures that when a new plan is generated, any previous progress for that chat is cleared, allowing tasks to correctly show as pending.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5a27e2f-dde6-4176-a38c-0c9817df8ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5a27e2f-dde6-4176-a38c-0c9817df8ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

