### PR TITLE
Handle gemini api quota exceeded errors

### DIFF
--- a/core/main/src/main/java/com/rk/settings/Settings.kt
+++ b/core/main/src/main/java/com/rk/settings/Settings.kt
@@ -13,6 +13,7 @@ import com.rk.components.compose.preferences.normal.Preference
 import com.rk.libcommons.application
 import com.rk.terminal.ui.screens.settings.WorkingMode
 import java.nio.charset.Charset
+import org.json.JSONArray
 
 object Settings {
     //Boolean
@@ -113,6 +114,36 @@ object Settings {
     var api_model
         get() = Preference.getString(key = "api_model", default = "gpt-4o-mini")
         set(value) = Preference.setString(key = "api_model", value)
+
+    // Gemini API key rotation
+    var api_key_rotation_enabled
+        get() = Preference.getBoolean(key = "api_key_rotation_enabled", default = false)
+        set(value) = Preference.setBoolean(key = "api_key_rotation_enabled", value)
+
+    var gemini_api_keys_json
+        get() = Preference.getString(key = "gemini_api_keys_json", default = "[]")
+        set(value) = Preference.setString(key = "gemini_api_keys_json", value)
+
+    fun getGeminiApiKeys(): MutableList<String> {
+        return try {
+            val arr = JSONArray(gemini_api_keys_json)
+            val list = ArrayList<String>(arr.length())
+            for (i in 0 until arr.length()) {
+                val k = arr.optString(i)
+                if (!k.isNullOrBlank()) list.add(k)
+            }
+            list
+        } catch (_: Exception) {
+            mutableListOf()
+        }
+    }
+
+    fun setGeminiApiKeys(keys: List<String>) {
+        val sanitized = keys.map { it.trim() }.filter { it.isNotEmpty() }
+        val arr = JSONArray()
+        sanitized.forEach { arr.put(it) }
+        gemini_api_keys_json = arr.toString()
+    }
 
     // Helper agent toggle
     var helper_agent_enabled

--- a/core/main/src/main/java/com/rk/terminal/llm/ApiEngines.kt
+++ b/core/main/src/main/java/com/rk/terminal/llm/ApiEngines.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.delay
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -223,31 +224,64 @@ object GeminiEngine : LlmEngine {
                     })
                 ))
             }
-            val req = Request.Builder()
-                .url(url)
-                .addHeader("content-type", "application/json")
-                .post(contents.toString().toRequestBody("application/json".toMediaType()))
-                .build()
 
-            ApiHttp.client.newCall(req).execute().use { resp ->
-                if (!resp.isSuccessful) {
-                    emit("[Gemini] HTTP ${resp.code}: ${resp.message}\n")
-                    val err = resp.body?.string()
-                    if (!err.isNullOrBlank()) emit(err.take(2000))
-                    return@use
+            var completed = false
+            while (!completed) {
+                val req = Request.Builder()
+                    .url(url)
+                    .addHeader("content-type", "application/json")
+                    .post(contents.toString().toRequestBody("application/json".toMediaType()))
+                    .build()
+                var shouldRetry = false
+                ApiHttp.client.newCall(req).execute().use { resp ->
+                    if (!resp.isSuccessful) {
+                        val errTxt = resp.body?.string().orEmpty()
+                        var isQuota = resp.code == 429
+                        if (!errTxt.isBlank()) {
+                            val errorObj = runCatching { JSONObject(errTxt) }.getOrNull()?.optJSONObject("error")
+                            val statusStr = errorObj?.optString("status").orEmpty()
+                            if (statusStr == "RESOURCE_EXHAUSTED") isQuota = true
+                            val detailsArr = errorObj?.optJSONArray("details") ?: JSONArray()
+                            for (i in 0 until detailsArr.length()) {
+                                val det = detailsArr.optJSONObject(i)
+                                val typeStr = det?.optString("@type").orEmpty()
+                                if (typeStr.endsWith("google.rpc.QuotaFailure") || typeStr.endsWith("google.rpc.RetryInfo")) {
+                                    isQuota = true
+                                    break
+                                }
+                            }
+                            if (!isQuota && (errTxt.contains("GenerateContentInputTokensPerModelPerMinute-FreeTier", true) || errTxt.contains("generate_content_free_tier_input_token_count", true))) isQuota = true
+                        }
+                        if (isQuota) {
+                            emit("RPM exceeded, retrying to access the API again in 5 seconds...\n")
+                            shouldRetry = true
+                            return@use
+                        } else {
+                            emit("[Gemini] HTTP ${resp.code}: ${resp.message}\n")
+                            if (errTxt.isNotBlank()) emit(errTxt.take(2000))
+                            completed = true
+                            return@use
+                        }
+                    }
+                    val txt = resp.body?.string().orEmpty()
+                    val obj = runCatching { JSONObject(txt) }.getOrNull()
+                    val cand = obj?.optJSONArray("candidates")?.optJSONObject(0)
+                    val parts = cand?.optJSONObject("content")?.optJSONArray("parts") ?: JSONArray()
+                    val sb = StringBuilder()
+                    for (i in 0 until parts.length()) {
+                        val part = parts.getJSONObject(i)
+                        val fragment = part.optString("text")
+                        if (fragment.isNotEmpty()) sb.append(fragment)
+                    }
+                    val out = sb.toString()
+                    if (out.isEmpty()) emit("[Gemini] Empty response\n") else out.chunked(64).forEach { emit(it) }
+                    completed = true
                 }
-                val txt = resp.body?.string().orEmpty()
-                val obj = runCatching { JSONObject(txt) }.getOrNull()
-                val cand = obj?.optJSONArray("candidates")?.optJSONObject(0)
-                val parts = cand?.optJSONObject("content")?.optJSONArray("parts") ?: JSONArray()
-                val sb = StringBuilder()
-                for (i in 0 until parts.length()) {
-                    val part = parts.getJSONObject(i)
-                    val fragment = part.optString("text")
-                    if (fragment.isNotEmpty()) sb.append(fragment)
+                if (!completed && shouldRetry) {
+                    delay(5000)
+                } else {
+                    break
                 }
-                val out = sb.toString()
-                if (out.isEmpty()) emit("[Gemini] Empty response\n") else out.chunked(64).forEach { emit(it) }
             }
         } catch (e: java.io.IOException) {
             throw e
@@ -288,7 +322,6 @@ object OllamaEngine : LlmEngine {
                 while (true) {
                     val line = source.readUtf8Line() ?: break
                     if (line.isBlank()) continue
-                    // Ollama streams JSON lines like {"message":{"content":"...","role":"assistant"},"done":false}
                     var shouldBreak = false
                     try {
                         val obj = JSONObject(line)
@@ -298,7 +331,6 @@ object OllamaEngine : LlmEngine {
                         if (content.isNotEmpty()) emit(content)
                         if (done) shouldBreak = true
                     } catch (_: Exception) {
-                        // tolerate occasional non-JSON lines
                     }
                     if (shouldBreak) break
                 }

--- a/core/main/src/main/java/com/rk/terminal/llm/ApiEngines.kt
+++ b/core/main/src/main/java/com/rk/terminal/llm/ApiEngines.kt
@@ -207,7 +207,6 @@ object GeminiEngine : LlmEngine {
     override fun generate(messages: List<LlmMessage>): Flow<String> = flow {
         try {
             val model = Settings.api_model.ifBlank { "gemini-1.5-flash" }
-            val url = "https://generativelanguage.googleapis.com/v1beta/models/$model:generateContent?key=${Settings.api_key}"
             val userText = messages.filter { it.role == "user" }.joinToString("\n\n") { it.content }
             val sys = messages.firstOrNull { it.role == "system" }?.content
             val forceJson = messages.any { it.content.contains("Return ONLY") && it.content.contains("JSON", ignoreCase = true) }
@@ -225,62 +224,133 @@ object GeminiEngine : LlmEngine {
                 ))
             }
 
-            var completed = false
-            while (!completed) {
-                val req = Request.Builder()
-                    .url(url)
-                    .addHeader("content-type", "application/json")
-                    .post(contents.toString().toRequestBody("application/json".toMediaType()))
-                    .build()
-                var shouldRetry = false
-                ApiHttp.client.newCall(req).execute().use { resp ->
-                    if (!resp.isSuccessful) {
-                        val errTxt = resp.body?.string().orEmpty()
-                        var isQuota = resp.code == 429
-                        if (!errTxt.isBlank()) {
-                            val errorObj = runCatching { JSONObject(errTxt) }.getOrNull()?.optJSONObject("error")
-                            val statusStr = errorObj?.optString("status").orEmpty()
-                            if (statusStr == "RESOURCE_EXHAUSTED") isQuota = true
-                            val detailsArr = errorObj?.optJSONArray("details") ?: JSONArray()
-                            for (i in 0 until detailsArr.length()) {
-                                val det = detailsArr.optJSONObject(i)
-                                val typeStr = det?.optString("@type").orEmpty()
-                                if (typeStr.endsWith("google.rpc.QuotaFailure") || typeStr.endsWith("google.rpc.RetryInfo")) {
-                                    isQuota = true
-                                    break
+            val rotationEnabled = Settings.api_key_rotation_enabled
+            val keys = Settings.getGeminiApiKeys().filter { it.isNotBlank() }
+            val useRotation = rotationEnabled && keys.isNotEmpty()
+
+            if (useRotation) {
+                var index = 0
+                var completed = false
+                while (!completed) {
+                    var exhaustedThisCycle = 0
+                    for (i in keys.indices) {
+                        val currentKey = keys[index]
+                        val url = "https://generativelanguage.googleapis.com/v1beta/models/$model:generateContent?key=${currentKey}"
+                        val req = Request.Builder()
+                            .url(url)
+                            .addHeader("content-type", "application/json")
+                            .post(contents.toString().toRequestBody("application/json".toMediaType()))
+                            .build()
+                        ApiHttp.client.newCall(req).execute().use { resp ->
+                            if (!resp.isSuccessful) {
+                                val errTxt = resp.body?.string().orEmpty()
+                                var isQuota = resp.code == 429
+                                if (!errTxt.isBlank()) {
+                                    val errorObj = runCatching { JSONObject(errTxt) }.getOrNull()?.optJSONObject("error")
+                                    val statusStr = errorObj?.optString("status").orEmpty()
+                                    if (statusStr == "RESOURCE_EXHAUSTED") isQuota = true
+                                    val detailsArr = errorObj?.optJSONArray("details") ?: JSONArray()
+                                    for (j in 0 until detailsArr.length()) {
+                                        val det = detailsArr.optJSONObject(j)
+                                        val typeStr = det?.optString("@type").orEmpty()
+                                        if (typeStr.endsWith("google.rpc.QuotaFailure") || typeStr.endsWith("google.rpc.RetryInfo")) {
+                                            isQuota = true
+                                            break
+                                        }
+                                    }
+                                    if (!isQuota && (errTxt.contains("GenerateContentInputTokensPerModelPerMinute-FreeTier", true) || errTxt.contains("generate_content_free_tier_input_token_count", true))) isQuota = true
+                                }
+                                if (isQuota) {
+                                    exhaustedThisCycle += 1
+                                    index = (index + 1) % keys.size
+                                    return@use
+                                } else {
+                                    emit("[Gemini] HTTP ${resp.code}: ${resp.message}\n")
+                                    if (errTxt.isNotBlank()) emit(errTxt.take(2000))
+                                    completed = true
+                                    return@use
                                 }
                             }
-                            if (!isQuota && (errTxt.contains("GenerateContentInputTokensPerModelPerMinute-FreeTier", true) || errTxt.contains("generate_content_free_tier_input_token_count", true))) isQuota = true
-                        }
-                        if (isQuota) {
-                            emit("RPM exceeded, retrying to access the API again in 5 seconds...\n")
-                            shouldRetry = true
-                            return@use
-                        } else {
-                            emit("[Gemini] HTTP ${resp.code}: ${resp.message}\n")
-                            if (errTxt.isNotBlank()) emit(errTxt.take(2000))
+                            val txt = resp.body?.string().orEmpty()
+                            val obj = runCatching { JSONObject(txt) }.getOrNull()
+                            val cand = obj?.optJSONArray("candidates")?.optJSONObject(0)
+                            val parts = cand?.optJSONObject("content")?.optJSONArray("parts") ?: JSONArray()
+                            val sb = StringBuilder()
+                            for (j in 0 until parts.length()) {
+                                val part = parts.getJSONObject(j)
+                                val fragment = part.optString("text")
+                                if (fragment.isNotEmpty()) sb.append(fragment)
+                            }
+                            val out = sb.toString()
+                            if (out.isEmpty()) emit("[Gemini] Empty response\n") else out.chunked(64).forEach { emit(it) }
                             completed = true
-                            return@use
                         }
+                        if (completed) break
                     }
-                    val txt = resp.body?.string().orEmpty()
-                    val obj = runCatching { JSONObject(txt) }.getOrNull()
-                    val cand = obj?.optJSONArray("candidates")?.optJSONObject(0)
-                    val parts = cand?.optJSONObject("content")?.optJSONArray("parts") ?: JSONArray()
-                    val sb = StringBuilder()
-                    for (i in 0 until parts.length()) {
-                        val part = parts.getJSONObject(i)
-                        val fragment = part.optString("text")
-                        if (fragment.isNotEmpty()) sb.append(fragment)
+                    if (!completed && exhaustedThisCycle >= keys.size) {
+                        emit("All API keys exceeded RPM. Retrying again in 5 seconds...\n")
+                        delay(5000)
                     }
-                    val out = sb.toString()
-                    if (out.isEmpty()) emit("[Gemini] Empty response\n") else out.chunked(64).forEach { emit(it) }
-                    completed = true
                 }
-                if (!completed && shouldRetry) {
-                    delay(5000)
-                } else {
-                    break
+            } else {
+                var completed = false
+                while (!completed) {
+                    val url = "https://generativelanguage.googleapis.com/v1beta/models/$model:generateContent?key=${Settings.api_key}"
+                    val req = Request.Builder()
+                        .url(url)
+                        .addHeader("content-type", "application/json")
+                        .post(contents.toString().toRequestBody("application/json".toMediaType()))
+                        .build()
+                    var shouldRetry = false
+                    ApiHttp.client.newCall(req).execute().use { resp ->
+                        if (!resp.isSuccessful) {
+                            val errTxt = resp.body?.string().orEmpty()
+                            var isQuota = resp.code == 429
+                            if (!errTxt.isBlank()) {
+                                val errorObj = runCatching { JSONObject(errTxt) }.getOrNull()?.optJSONObject("error")
+                                val statusStr = errorObj?.optString("status").orEmpty()
+                                if (statusStr == "RESOURCE_EXHAUSTED") isQuota = true
+                                val detailsArr = errorObj?.optJSONArray("details") ?: JSONArray()
+                                for (i in 0 until detailsArr.length()) {
+                                    val det = detailsArr.optJSONObject(i)
+                                    val typeStr = det?.optString("@type").orEmpty()
+                                    if (typeStr.endsWith("google.rpc.QuotaFailure") || typeStr.endsWith("google.rpc.RetryInfo")) {
+                                        isQuota = true
+                                        break
+                                    }
+                                }
+                                if (!isQuota && (errTxt.contains("GenerateContentInputTokensPerModelPerMinute-FreeTier", true) || errTxt.contains("generate_content_free_tier_input_token_count", true))) isQuota = true
+                            }
+                            if (isQuota) {
+                                emit("RPM exceeded, retrying to access the API again in 5 seconds...\n")
+                                shouldRetry = true
+                                return@use
+                            } else {
+                                emit("[Gemini] HTTP ${resp.code}: ${resp.message}\n")
+                                if (errTxt.isNotBlank()) emit(errTxt.take(2000))
+                                completed = true
+                                return@use
+                            }
+                        }
+                        val txt = resp.body?.string().orEmpty()
+                        val obj = runCatching { JSONObject(txt) }.getOrNull()
+                        val cand = obj?.optJSONArray("candidates")?.optJSONObject(0)
+                        val parts = cand?.optJSONObject("content")?.optJSONArray("parts") ?: JSONArray()
+                        val sb = StringBuilder()
+                        for (i in 0 until parts.length()) {
+                            val part = parts.getJSONObject(i)
+                            val fragment = part.optString("text")
+                            if (fragment.isNotEmpty()) sb.append(fragment)
+                        }
+                        val out = sb.toString()
+                        if (out.isEmpty()) emit("[Gemini] Empty response\n") else out.chunked(64).forEach { emit(it) }
+                        completed = true
+                    }
+                    if (!completed && shouldRetry) {
+                        delay(5000)
+                    } else if (completed) {
+                        break
+                    }
                 }
             }
         } catch (e: java.io.IOException) {

--- a/core/main/src/main/java/com/rk/terminal/ui/screens/settings/Settings.kt
+++ b/core/main/src/main/java/com/rk/terminal/ui/screens/settings/Settings.kt
@@ -32,6 +32,8 @@ import com.rk.terminal.ui.activities.terminal.MainActivity
 import com.rk.terminal.ui.components.SettingsToggle
 import com.rk.terminal.ui.routes.MainActivityRoutes
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.runtime.snapshots.SnapshotStateList
 
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -218,6 +220,70 @@ fun Settings(modifier: Modifier = Modifier,navController: NavController,mainActi
                 } else {
                     "Chat will use these API settings. Local model download and folders have been replaced."
                 }, modifier = Modifier.padding(top = 8.dp))
+            }
+        }
+
+        // Gemini API key rotation
+        PreferenceGroup(heading = "Gemini Key Rotation") {
+            var rotationEnabled by remember { mutableStateOf(Settings.api_key_rotation_enabled) }
+            SettingsToggle(
+                label = "Enable API Key Rotation",
+                description = "Use multiple Gemini API keys and rotate when rate limited",
+                showSwitch = true,
+                default = rotationEnabled,
+                sideEffect = { checked ->
+                    rotationEnabled = checked
+                    Settings.api_key_rotation_enabled = checked
+                }
+            )
+
+            if (rotationEnabled) {
+                val keys: SnapshotStateList<String> = remember { mutableStateListOf<String>().also { it.addAll(Settings.getGeminiApiKeys()) } }
+                var newKey by remember { mutableStateOf("") }
+                Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                    Row(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                        OutlinedTextField(
+                            value = newKey,
+                            onValueChange = { newKey = it },
+                            label = { Text("Add Gemini API key") },
+                            modifier = Modifier.weight(1f),
+                            singleLine = true
+                        )
+                        OutlinedButton(modifier = Modifier.padding(start = 8.dp), onClick = {
+                            val trimmed = newKey.trim()
+                            if (trimmed.isNotEmpty()) {
+                                keys.add(trimmed)
+                                Settings.setGeminiApiKeys(keys)
+                                newKey = ""
+                            }
+                        }) { Text("Add") }
+                    }
+
+                    // Existing keys list with remove/up/down
+                    keys.forEachIndexed { index, k ->
+                        Row(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                            Text(text = "${index + 1}. ${k}", modifier = Modifier.weight(1f))
+                            OutlinedButton(onClick = {
+                                if (index > 0) {
+                                    val moved = keys.removeAt(index)
+                                    keys.add(index - 1, moved)
+                                    Settings.setGeminiApiKeys(keys)
+                                }
+                            }) { Text("Up") }
+                            OutlinedButton(modifier = Modifier.padding(start = 8.dp), onClick = {
+                                if (index < keys.lastIndex) {
+                                    val moved = keys.removeAt(index)
+                                    keys.add(index + 1, moved)
+                                    Settings.setGeminiApiKeys(keys)
+                                }
+                            }) { Text("Down") }
+                            OutlinedButton(modifier = Modifier.padding(start = 8.dp), onClick = {
+                                keys.removeAt(index)
+                                Settings.setGeminiApiKeys(keys)
+                            }) { Text("Remove") }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Adds retry handling for Gemini API 429 quota errors to ensure continuous operation.

---
<a href="https://cursor.com/background-agent?bcId=bc-949d9438-d0f4-40f8-868f-fd3f2df0885d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-949d9438-d0f4-40f8-868f-fd3f2df0885d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

